### PR TITLE
fix: 小程序preflight选择器调整

### DIFF
--- a/src/postcss/mp.ts
+++ b/src/postcss/mp.ts
@@ -21,8 +21,8 @@ export function commonChunkPreflight (node: Rule, cssInjectPreflight: InjectPref
   // 变量注入和 preflight
   if (/::before/.test(node.selector) && /::after/.test(node.selector)) {
     const selectorParts = node.selector.split(',')
-    if (!selectorParts.includes('view')) {
-      selectorParts.push('view')
+    if (!selectorParts.includes(':not(not)')) {
+      selectorParts.push(':not(not)')
       node.selector = selectorParts.join(',')
     }
 


### PR DESCRIPTION
只使用view其他基础组件无法覆盖，使用:not(not)替代